### PR TITLE
Update Failure reporting.

### DIFF
--- a/Xunit.ScenarioReporting/Constants.cs
+++ b/Xunit.ScenarioReporting/Constants.cs
@@ -7,6 +7,9 @@ namespace Xunit.ScenarioReporting
     {
         internal const string XmlTagAssembly = "Assembly";
         internal const string XmlTagName = "Name";
+        internal const string XmlTagValue = "Value";
+        internal const string XmlTagExpected = "Expected";
+        internal const string XmlTagActual = "Actual";
         internal const string XmlTagTime = "Time";
         internal const string XmlTagScenario = "Definition";
         internal const string XmlTagGiven = "Given";
@@ -16,7 +19,12 @@ namespace Xunit.ScenarioReporting
         internal const string XmlTagTitle = "Title";
         internal const string XmlTagDetail = "Detail";
         internal const string XmlTagMessage = "Message";
-        internal const string XmlTagFailure = "Failure";
+
+        //Error reporting
+        internal const string XmlTagFailure = "Failure"; 
+        internal const string XmlTagMismatch = "Mismatch";
+        internal const string XmlTagException = "Exception";
+
         internal const string ReportAssemblyOverviewHtmlHeader = "ReportAssemblyOverviewHTMLHeader.html";
         internal const string ReportAssemblyOverviewHtmlContent = "ReportAssemblyOverviewHTMLContent.xslt";
         internal const string ReportAssemblyOverviewHtmlFooter = "ReportAssemblyOverviewHTMLFooter.html";

--- a/Xunit.ScenarioReporting/Reports/ReportAssemblyOverviewHTMLContent.xslt
+++ b/Xunit.ScenarioReporting/Reports/ReportAssemblyOverviewHTMLContent.xslt
@@ -31,16 +31,15 @@
 
         <a name="{generate-id(Name)}"></a>
         <section class="section-scenario">
-
         <xsl:if test="descendant::Failure">
           <xsl:attribute name="class">section-scenario status-failure</xsl:attribute>
-          <svg class="icon icon-lemon-2"><use xlink:href="#icon-lemon-2"></use></svg>
+          <svg class="icon icon-lemon-2 jello animated"><use xlink:href="#icon-lemon-2"></use></svg>
           <!--::THERE IS A FAILURE::-->
         </xsl:if>
 
         <h3>Scenario</h3>
         <p>Name: <xsl:value-of select="Name"/></p>
-
+        <p>Nom de guerre: <xsl:value-of select="NDG"/></p>
 				<div class="section-givens">
 				<h4>Given</h4>
 				<xsl:variable name="cntGivens" select="count(Given)" />
@@ -53,7 +52,12 @@
 						<div class="section-given">
 						<p><xsl:value-of select="Title"/></p><!--Title-->
 						<xsl:if test="Detail != ''" >
-							<p>with <xsl:for-each select="Detail/Message"><xsl:value-of select="concat(., ' ')"/></xsl:for-each ></p><!--Message-->
+							<!--<p>with <xsl:for-each select="Detail/Message"><xsl:value-of select="concat(., ' ')"/></xsl:for-each ></p>--><!--Message-->
+              <p>with 
+              <xsl:for-each select="Detail/.">
+                <xsl:value-of select="Name"/><xsl:text> </xsl:text><xsl:value-of select="Value"/>              
+              </xsl:for-each>
+              </p>
 						</xsl:if>						
 						</div><!--section-given-->
             <!--<xsl:if test="position() != last()"> [and] </xsl:if>-->
@@ -74,8 +78,13 @@
 						<div class="section-when">
 						<p><xsl:value-of select="Title"/></p><!--Title-->
 						<xsl:if test="Detail != ''" >
-							<p>with <xsl:for-each select="Detail/Message"><xsl:value-of select="concat(., ' ')"/></xsl:for-each ></p><!--Message-->
-						</xsl:if>						
+							<!--<p>with <xsl:for-each select="Detail/Message"><xsl:value-of select="concat(., ' ')"/></xsl:for-each ></p>--><!--Message-->
+              <p>with 
+              <xsl:for-each select="Detail/.">
+                <xsl:value-of select="Name"/><xsl:text> </xsl:text><xsl:value-of select="Value"/>              
+              </xsl:for-each>
+              </p>
+            </xsl:if>						
 						</div><!--section-when-->
 					</xsl:for-each >				
 				</xsl:otherwise>
@@ -91,11 +100,13 @@
 				</xsl:when>
 				<xsl:otherwise>
 					<xsl:for-each select="Then">
-						<div class="section-then">
+						<div class="section-then"><!--
             <xsl:if test="descendant::Failure">
               <xsl:attribute name="class">section-then status-failure</xsl:attribute>
-            </xsl:if>
+            </xsl:if>-->
 						<p><xsl:value-of select="Title"/></p><!--Title-->
+  
+              <!--
               <xsl:if test="count(Detail/Message) > 0" >
                 <p>with 
                   <xsl:for-each select="Detail/Message">
@@ -103,21 +114,41 @@
                   </xsl:for-each >
                 </p>
               </xsl:if>
+               -->
 
-              <xsl:if test="count(Detail/Failure) > 0" >
-                <p class="status-failure">
-                  <xsl:for-each select="Detail/Failure">
-                    <xsl:value-of select="concat(., ' ')"/>::FAILURE::
+              <xsl:choose>
+                <xsl:when test="count(Detail/Failure) > 0">
+                <div class="status-failure">
+                  <xsl:for-each select="Detail/Failure/Mismatch">
+                    <!--<xsl:value-of select="concat(., ' ')"/>::FAILURE::-->
+                    <p><xsl:value-of select="Name"/> Mismatch:</p>
+                    <ul>
+                      <li>Expected: <xsl:value-of select="Expected/Value"/></li>
+                      <li>Actual: <xsl:value-of select="Actual/Value"/></li>
+                    </ul>
+                    <!--::FAILURE::-->
+                    <svg class="icon icon-error-x"><use xlink:href="#icon-error-x"></use></svg>
                   </xsl:for-each >
-                </p>
-              </xsl:if>
-
+                </div>
+                </xsl:when>
+                <xsl:otherwise>
+                  <xsl:if test="count(Detail/.) > 0" >
+                    <p>with  
+                      <xsl:for-each select="Detail/.">
+                        <xsl:value-of select="Name"/><xsl:text> </xsl:text><xsl:value-of select="Value"/>              
+                      </xsl:for-each>
+                    </p>
+                  </xsl:if>
+                </xsl:otherwise>              
+              </xsl:choose>
+              
             </div><!--section-then-->
 					</xsl:for-each >
 				</xsl:otherwise>
 				</xsl:choose>
 				</div><!--section-thens-->
 				<p><a href="#top">Back to top</a></p>
+
         </section><!--section-scenario-->
     </xsl:for-each>
 

--- a/Xunit.ScenarioReporting/Reports/ReportAssemblyOverviewHTMLHeader.html
+++ b/Xunit.ScenarioReporting/Reports/ReportAssemblyOverviewHTMLHeader.html
@@ -80,6 +80,7 @@
 		.section-thens {
 			border-radius: 5px; 
 			box-shadow:0 10px 15px -10px #777;
+            overflow-wrap:break-word;
 		}
 		.section-scenario {
 			box-shadow:0 20px 15px -15px #555;
@@ -101,10 +102,13 @@
             color:crimson;
         }
 
+        .menu-item {
+            overflow-wrap:break-word;
+        }
         .section-scenario.status-failure {
             border-left: 0.4em solid crimson;
         }
-        .section-then.status-failure {
+        .section-then .status-failure {
             border-left: 0.2em solid crimson;
             padding-left: 0.5em;
         }
@@ -120,20 +124,100 @@
         .icon-lemon-2 {
             font-size: 1.6em;
         }
+
+        .icon-error-x {
+            font-size: 3.2em;
+        }
+
+
+        .animated {
+            animation-duration: 1s;
+            animation-fill-mode: both;
+        }
+
+        @keyframes jello {
+            from, 11.1%, to {
+                transform: none;
+            }
+
+            22.2% {
+                transform: skewX(-12.5deg) skewY(-12.5deg);
+            }
+
+            33.3% {
+                transform: skewX(6.25deg) skewY(6.25deg);
+            }
+
+            44.4% {
+                transform: skewX(-3.125deg) skewY(-3.125deg);
+            }
+
+            55.5% {
+                transform: skewX(1.5625deg) skewY(1.5625deg);
+            }
+
+            66.6% {
+                transform: skewX(-0.78125deg) skewY(-0.78125deg);
+            }
+
+            77.7% {
+                transform: skewX(0.390625deg) skewY(0.390625deg);
+            }
+
+            88.8% {
+                transform: skewX(-0.1953125deg) skewY(-0.1953125deg);
+            }
+        }
+
+        .jello {
+            animation-name: jello;
+            transform-origin: center;
+        }
+
 	</style>
+
   </head>
   <body>  
     <svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 512 512" xml:space="preserve">
         <defs>
             <symbol id="icon-lemon-2" viewBox="0 0 512 512">
-            <path style="fill:#F4DE3B;" d="M452.541,261.129c0-100.923-63.981-185.539-150.123-208.285c0.254-1.975,0.399-3.985,0.399-6.029
-	            C302.816,20.961,281.856,0,256.001,0s-46.816,20.961-46.816,46.817c0,2.044,0.145,4.054,0.399,6.029
-	            C123.441,75.592,59.459,160.206,59.459,261.129c0,100.844,63.881,185.405,149.921,208.231c2.116,23.896,22.175,42.635,46.621,42.635
-	            s44.505-18.739,46.621-42.635C388.66,446.534,452.541,361.973,452.541,261.129z" />
-            <path style="fill:#D6BD27;" d="M256.004,512c-24.446,0-44.503-18.748-46.621-42.643C123.341,446.528,59.46,361.974,59.46,261.136
-	            c0-100.928,63.983-185.546,150.129-208.286c-0.257-1.976-0.411-3.991-0.411-6.031c0-25.858,20.968-46.813,46.826-46.813
-	            c-8.957,0-16.22,20.956-16.22,46.813c0,2.04,0.051,4.055,0.141,6.031c-29.823,22.739-51.985,107.357-51.985,208.286
-	            c0,100.839,22.123,185.392,51.921,208.222C240.593,493.252,247.535,512,256.004,512z" />
+                <path style="fill:#F4DE3B;" d="M452.541,261.129c0-100.923-63.981-185.539-150.123-208.285c0.254-1.975,0.399-3.985,0.399-6.029
+	                C302.816,20.961,281.856,0,256.001,0s-46.816,20.961-46.816,46.817c0,2.044,0.145,4.054,0.399,6.029
+	                C123.441,75.592,59.459,160.206,59.459,261.129c0,100.844,63.881,185.405,149.921,208.231c2.116,23.896,22.175,42.635,46.621,42.635
+	                s44.505-18.739,46.621-42.635C388.66,446.534,452.541,361.973,452.541,261.129z" />
+                <path style="fill:#D6BD27;" d="M256.004,512c-24.446,0-44.503-18.748-46.621-42.643C123.341,446.528,59.46,361.974,59.46,261.136
+	                c0-100.928,63.983-185.546,150.129-208.286c-0.257-1.976-0.411-3.991-0.411-6.031c0-25.858,20.968-46.813,46.826-46.813
+	                c-8.957,0-16.22,20.956-16.22,46.813c0,2.04,0.051,4.055,0.141,6.031c-29.823,22.739-51.985,107.357-51.985,208.286
+	                c0,100.839,22.123,185.392,51.921,208.222C240.593,493.252,247.535,512,256.004,512z" />
             </symbol>
         </defs>
+    </svg>
+
+    <svg style="position: absolute; width: 0; height: 0; overflow: hidden" version="1.1" viewBox="0 0 612 792" xml:space="preserve" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <style type="text/css">
+            .st0 {
+                clip-path: url(#SVGID_2_);
+                fill: none;
+                stroke: crimson;
+                stroke-width: 45;
+            }
+
+            .st1 {
+                fill: crimson; /*#E44061;*/
+            }
+        </style>
+        <symbol id="icon-error-x" viewBox="0 0 612 792">
+        <g>
+        <g>
+        <defs>
+            <rect height="512" id="SVGID_1_" width="512" x="50" y="140" />
+        </defs>
+        <clipPath id="SVGID_2_">
+        <use style="overflow:visible;" xlink:href="#SVGID_1_" />
+        </clipPath>
+        <path class="st0" d="M306,629.5c128.8,0,233.5-104.7,233.5-233.5S434.8,162.5,306,162.5S72.5,267.2,72.5,396    S177.2,629.5,306,629.5L306,629.5z" />
+        </g>
+        <polygon class="st1" points="348.7,396 448,296.7 405.3,254 306,353.3 206.7,254 164,296.7 263.3,396 164,495.3 206.7,538    306,438.7 405.3,538 448,495.3 348.7,396  " />
+        </g>
+        </symbol>
     </svg>


### PR DESCRIPTION
HTML reports show mismatch details and exception details (latter untested). (Markdown report remains unchanged.)

SVG Error icon added.

First pass at "wordifying" pascal-case strings.

Responsive word-break.