### PR TITLE
Respect verifyMessage parameter

### DIFF
--- a/Xunit.ScenarioReporting/ReflectionBasedScenarioRunner.cs
+++ b/Xunit.ScenarioReporting/ReflectionBasedScenarioRunner.cs
@@ -211,7 +211,7 @@ namespace Xunit.ScenarioReporting
 
                 void IWhen<TThen>.Throws<T>(T exception, bool verifyMessage)
                 {
-                    _scenarioDefinition = new ScenarioDefinition(_givens, _when, exception, true);
+                    _scenarioDefinition = new ScenarioDefinition(_givens, _when, exception, verifyMessage);
                 }
 
                 internal ScenarioDefinition Build()


### PR DESCRIPTION
Calling `Throws()` with `verifyMessage` set to `false` was still failing when messages were not identical.